### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 BinDeps
 SampledSignals 0.3.0
 RingBuffers 1.0.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6.0-pre
+julia 0.6.0-dev.2746
 BinDeps
 SampledSignals 0.3.0
 RingBuffers 1.0.0


### PR DESCRIPTION
`mutable struct` syntax won't work on early 0.6.0-dev versions,
so better to stick to the julia-0.5-compatible versions of the package there