### PR TITLE
getting a warning when executing regarding abs()

### DIFF
--- a/examples/audiometer.jl
+++ b/examples/audiometer.jl
@@ -9,7 +9,7 @@ function micmeter(metersize)
     println("Press Ctrl-C to quit")
     while true
         block = read(mic, 512)
-        blockmax = maximum(abs(block)) # find the maximum value in the block
+        blockmax = maximum(abs.(block)) # find the maximum value in the block
         signalmax = max(signalmax, blockmax) # keep the maximum value ever
         print("\r") # reset the cursor to the beginning of the line
         printmeter(metersize, blockmax, signalmax)

--- a/examples/spectrum.jl
+++ b/examples/spectrum.jl
@@ -14,7 +14,7 @@ const fs = Float32[float(f) for f in domain(fft(buf)[fmin..fmax])]
 
 while true
     read!(stream, buf)
-    plot(fs, abs(fft(buf)[fmin..fmax]), xlim=(fs[1],fs[end]), ylim=(0,100))
+    plot(fs, abs.(fft(buf)[fmin..fmax]), xlim=(fs[1],fs[end]), ylim=(0,100))
 end
 
 end


### PR DESCRIPTION
Small fix regarding the usage of `abs()` , was getting this warning when executing the example.

```
INFO: METADATA is out-of-date — you may not have the latest version of LibSndFile
INFO: Use `Pkg.update()` to get the latest versions of your packages
Press Ctrl-C to quit
WARNING: abs(x::AbstractArray{T}) where T <: Number is deprecated, use abs.(x) instead.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:70
 [2] abs(::SampledSignals.SampleBuf{Float32,2}) at ./deprecated.jl:57
 [3] micmeter(::Int64) at /Users/emcp/Dev/git/EMCP/bootstrap-julia-audio-record/bootstrap-record-audio.jl:17
 [4] include_string(::String, ::String) at ./loading.jl:522
 [5] include_string(::Module, ::String, ::String) at /Applications/JuliaPro-0.6.4.1.app/Contents/Resources/pkgs-0.6.4.1/v0.6/Compat/src/Compat.jl:88
 [6] (::Atom.##112#116{String,String})() at /Applications/JuliaPro-0.6.4.1.app/Contents/Resources/pkgs-0.6.4.1/v0.6/Atom/src/eval.jl:109
 [7] withpath(::Atom.##112#116{String,String}, ::String) at /Applications/JuliaPro-0.6.4.1.app/Contents/Resources/pkgs-0.6.4.1/v0.6/CodeTools/src/utils.jl:30
 [8] withpath(::Function, ::String) at /Applications/JuliaPro-0.6.4.1.app/Contents/Resources/pkgs-0.6.4.1/v0.6/Atom/src/eval.jl:38
 [9] hideprompt(::Atom.##111#115{String,String}) at /Applications/JuliaPro-0.6.4.1.app/Contents/Resources/pkgs-0.6.4.1/v0.6/Atom/src/repl.jl:67
 [10] macro expansion at /Applications/JuliaPro-0.6.4.1.app/Contents/Resources/pkgs-0.6.4.1/v0.6/Atom/src/eval.jl:106 [inlined]
 [11] (::Atom.##110#114{Dict{String,Any}})() at ./task.jl:80
```