### PR TITLE
Exposed 'latency' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PortAudio.jl is a wrapper for [libportaudio](http://www.portaudio.com/), which g
 The easiest way to open a source or sink is with the default `PortAudioStream()` constructor, which will open a 2-in, 2-out stream to your system's default device(s). The constructor can also take the input and output channel counts as positional arguments, or a variety of other keyword arguments.
 
 ```julia
-PortAudioStream(inchans=2, outchans=2; eltype=Float32, samplerate=48000Hz, blocksize=4096, synced=false)
+PortAudioStream(inchans=2, outchans=2; eltype=Float32, samplerate=48000Hz, latency=0.1, synced=false)
 ```
 
 You can open a specific device by adding it as the first argument, either as a `PortAudioDevice` instance or by name. You can also give separate names or devices if you want different input and output devices

--- a/examples/audiometer.jl
+++ b/examples/audiometer.jl
@@ -3,7 +3,7 @@ using PortAudio
 """Continuously read from the default audio input and plot an
 ASCII level/peak meter"""
 function micmeter(metersize)
-    mic = PortAudioStream(1, 0; latency=512)
+    mic = PortAudioStream(1, 0; latency=0.1)
 
     signalmax = zero(eltype(mic))
     println("Press Ctrl-C to quit")

--- a/examples/audiometer.jl
+++ b/examples/audiometer.jl
@@ -3,7 +3,7 @@ using PortAudio
 """Continuously read from the default audio input and plot an
 ASCII level/peak meter"""
 function micmeter(metersize)
-    mic = PortAudioStream(1, 0; blocksize=512)
+    mic = PortAudioStream(1, 0; latency=512)
 
     signalmax = zero(eltype(mic))
     println("Press Ctrl-C to quit")

--- a/examples/measure_latency.jl
+++ b/examples/measure_latency.jl
@@ -9,10 +9,10 @@ function create_measure_signal()
     return signal
 end
 
-function measure_latency(in_latency = 0.1, out_latency=0.1, blocksize = 32; is_warmup = false)
+function measure_latency(in_latency = 0.1, out_latency=0.1; is_warmup = false)
 
-    in_stream = PortAudioStream(1,0; latency=in_latency, blocksize=32)
-    out_stream = PortAudioStream(0,1; latency=out_latency, blocksize=32)
+    in_stream = PortAudioStream(1,0; latency=in_latency)
+    out_stream = PortAudioStream(0,1; latency=out_latency)
 
     cond = Base.Event()
 
@@ -60,9 +60,7 @@ measure_latency(0.1, 0.1, 32; is_warmup = true) # warmup
 latencies = [0.1, 0.01, 0.005]
 for in_latency in latencies
     for out_latency in latencies
-        for blocksize in [32]
-            measure = measure_latency(in_latency, out_latency, blocksize)
-            println("$measure ms latency for in_latency=$in_latency, out_latency=$out_latency, blocksize=$blocksize")
-        end
+        measure = measure_latency(in_latency, out_latency)
+        println("$measure ms latency for in_latency=$in_latency, out_latency=$out_latency")
     end
 end

--- a/examples/measure_latency.jl
+++ b/examples/measure_latency.jl
@@ -55,7 +55,7 @@ function measure_latency(in_latency = 0.1, out_latency=0.1; is_warmup = false)
     return trunc(Int, delay * 1000)# result in ms
 end
 
-measure_latency(0.1, 0.1, 32; is_warmup = true) # warmup
+measure_latency(0.1, 0.1; is_warmup = true) # warmup
 
 latencies = [0.1, 0.01, 0.005]
 for in_latency in latencies

--- a/examples/spectrum.jl
+++ b/examples/spectrum.jl
@@ -6,7 +6,7 @@ module SpectrumExample
 using GR, PortAudio, SampledSignals, FFTW
 
 const N = 1024
-const stream = PortAudioStream(1, 0, blocksize=N)
+const stream = PortAudioStream(1, 0)
 const buf = read(stream, N)
 const fmin = 0Hz
 const fmax = 10000Hz

--- a/examples/waterfall_heatmap.jl
+++ b/examples/waterfall_heatmap.jl
@@ -34,7 +34,7 @@ N = 1024 # size of audio read
 N2 = N÷2+1 # size of rfft output
 D = 200 # number of bins to display
 M = 200 # amount of history to keep
-src = PortAudioStream(1, 2, blocksize=N)
+src = PortAudioStream(1, 2)
 buf = Array{Float32}(N) # buffer for reading
 fftplan = plan_rfft(buf; flags=FFTW.EXHAUSTIVE)
 fftbuf = Array{Complex{Float32}}(N2) # destination buf for FFT

--- a/examples/waterfall_lines.jl
+++ b/examples/waterfall_lines.jl
@@ -6,7 +6,7 @@ N2 = N÷2+1 # size of rfft output
 D = 200 # number of bins to display
 M = 100 # number of lines to draw
 S = 0.5 # motion speed of lines
-src = PortAudioStream(1, 2, blocksize=N)
+src = PortAudioStream(1, 2)
 buf = Array{Float32}(N)
 fftbuf = Array{Complex{Float32}}(N2)
 magbuf = Array{Float32}(N2)

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -213,7 +213,6 @@ end
 isopen(stream::PortAudioStream) = stream.stream != C_NULL
 
 SampledSignals.samplerate(stream::PortAudioStream) = stream.samplerate
-SampledSignals.blocksize(stream::PortAudioStream) = trunc(Int, stream.samplerate * stream.latency)
 eltype(stream::PortAudioStream{T}) where T = T
 
 read(stream::PortAudioStream, args...) = read(stream.source, args...)
@@ -225,7 +224,6 @@ flush(stream::PortAudioStream) = flush(stream.sink)
 function show(io::IO, stream::PortAudioStream)
     println(io, typeof(stream))
     println(io, "  Samplerate: ", samplerate(stream), "Hz")
-    print(io, "  Buffer Size: ", blocksize(stream), " frames")
     if nchannels(stream.sink) > 0
         print(io, "\n  ", nchannels(stream.sink), " channel sink: \"", name(stream.sink), "\"")
     end
@@ -258,7 +256,6 @@ end
 
 SampledSignals.nchannels(s::Union{PortAudioSink, PortAudioSource}) = s.nchannels
 SampledSignals.samplerate(s::Union{PortAudioSink, PortAudioSource}) = samplerate(s.stream)
-SampledSignals.blocksize(s::Union{PortAudioSink, PortAudioSource}) = blocksize(s.stream)
 eltype(::Union{PortAudioSink{T}, PortAudioSource{T}}) where {T} = T
 function close(s::Union{PortAudioSink, PortAudioSource})
     throw(ErrorException("Attempted to close PortAudioSink or PortAudioSource.

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -103,7 +103,7 @@ mutable struct PortAudioStream{T}
     end
 end
 
-defaultlatency(f, devices...) = maximum(d -> max(d.highoutputlatency, d.highinputlatency), devices)
+defaultlatency(devices...) = maximum(d -> max(d.highoutputlatency, d.highinputlatency), devices)
 
 # this is the top-level outer constructor that all the other outer constructors end up calling
 """

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -103,9 +103,7 @@ mutable struct PortAudioStream{T}
     end
 end
 
-function defaultlatency(devices...)
-    return maximum(d -> d.highoutputlatency, devices) #TODO(jakubwro): add in/out and high/low logic
-end
+defaultlatency(f, devices...) = maximum(d -> max(d.highoutputlatency, d.highinputlatency), devices)
 
 # this is the top-level outer constructor that all the other outer constructors end up calling
 """


### PR DESCRIPTION
Now 'blocksize' param is removed compleatly, only latency is exposed.
I developed and tested on Ubuntu Studio, I will test on mac tomorrow, so let's postpone merge.

I noticed that low latency default on my linux is 0.005 (vs 0.017) mac. I have very rare buffer underruns due to that