### PR TITLE
Use the correct secrets key

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -22,5 +22,4 @@ jobs:
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          ssh: ${{ secrets.COMPATHELPER_PRIV }}


### PR DESCRIPTION
In 7e317452f9f21979ed4c68db4a7cdb807f1857ee the use of secret key 'DOCUMENTER_KEY' was added. However, if I open up the github settings page I only see `COMPATHELPER_PRIV`. As such, I have updated the workflows to match the key I can view.

But I am not a github expert, and maybe you see different keys to me due to permissions etc. @bramtayl feel free to close and discard this PR if it is incorrect.