### PR TITLE
MRG: Use github actions for tests and expand platforms and versions

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,0 +1,45 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags: '*'
+
+
+jobs:
+  test:
+    timeout-minutes: 30
+    name: ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} 
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1.1'
+          - '1.2'
+          - '1.3'
+          - '1.4'
+          - '1.5'
+          - '1'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -17,9 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.1'
-          - '1.2'
           - '1.3'
           - '1.4'
           - '1.5'

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -28,6 +28,7 @@ jobs:
           - windows-latest
         arch:
           - x64
+          - x86
 
     steps:
       - uses: actions/checkout@v2

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SampledSignals = "bd7594eb-a658-542f-9e75-4c4d8908c167"
 libportaudio_jll = "2d7b7beb-0762-5160-978e-1ab83a1e8a31"
 
 [compat]
-julia = "1"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SampledSignals = "bd7594eb-a658-542f-9e75-4c4d8908c167"
 libportaudio_jll = "2d7b7beb-0762-5160-978e-1ab83a1e8a31"
 
 [compat]
-julia = "1.3"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Adds github tests. And also tests explicitly on 3 OSs and several julia versions.

I expect julia 1.0, 1.1, and 1.2 will fail as these are not supported by PortAudio, I will then remove these from the matrix.