### PR TITLE
Send debug to debug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,11 +7,13 @@ version = "1.1.1"
 libportaudio_jll = "2d7b7beb-0762-5160-978e-1ab83a1e8a31"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SampledSignals = "bd7594eb-a658-542f-9e75-4c4d8908c167"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [compat]
 julia = "1.3"
 libportaudio_jll = "19.6.0"
 SampledSignals = "2.1.1"
+Suppressor = "0.2.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,8 @@ SampledSignals = "2.1.1"
 Suppressor = "0.2.0"
 
 [extras]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Logging", "Test"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ The `PortAudioStream` type has `source` and `sink` fields which are of type `Por
 
 PortAudio.jl also provides convenience wrappers around the `PortAudioStream` type so you can read and write to it directly, e.g. `write(stream, stream)` will set up a loopback that will read from the input and play it back on the output.
 
+## Debugging
+
+If you are experiencing issues and wish to view detailed logging and debug information, set
+
+```
+ENV["JULIA_DEBUG"] = :PortAudio
+```
+
+before using the package.
+
 ## Examples
 
 ### Set up an audio pass-through from microphone to speaker

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -95,10 +95,8 @@ mutable struct PortAudioStream{T}
         # finalizer(close, this)
         this.sink = PortAudioSink{T}(outdev.name, this, outchans)
         this.source = PortAudioSource{T}(indev.name, this, inchans)
-        this.stream = suppress_err() do
-            Pa_OpenStream(inparams, outparams, sr, 0, paNoFlag,
+        this.stream = @stderr_as_debug Pa_OpenStream(inparams, outparams, sr, 0, paNoFlag,
                           nothing, nothing)
-        end
 
         Pa_StartStream(this.stream)
         # pre-fill the output stream so we're less likely to underrun
@@ -369,9 +367,11 @@ function discard_input(source::PortAudioSource)
     end
 end
 
-function suppress_err(dofunc::Function)
-    debug_message = @suppress_err dofunc()
-    @debug debug_message
+macro stderr_as_debug(expression)
+    quote
+        debug_message = @capture_err $(esc(expression))
+        @debug debug_message
+    end
 end
 
 function __init__()
@@ -407,9 +407,7 @@ function __init__()
     # junk to STDOUT on initialization, so we swallow it.
     # TODO: actually check the junk to make sure there's nothing in there we
     # don't expect
-    suppress_err() do
-        Pa_Initialize()
-    end
+    @stderr_as_debug Pa_Initialize()
 
     atexit() do
         Pa_Terminate()

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -1,6 +1,6 @@
 module PortAudio
 
-using libportaudio_jll: libportaudio_jll
+using libportaudio_jll: libportaudio
 using SampledSignals
 using Suppressor: @capture_err
 
@@ -14,6 +14,15 @@ import LinearAlgebra: transpose!
 export PortAudioStream
 
 include("libportaudio.jl")
+
+macro stderr_as_debug(expression)
+    quote
+        local result
+        debug_message = @capture_err result = $(esc(expression))
+        @debug "$debug_message"
+        result
+    end
+end
 
 # This size is in frames
 
@@ -364,14 +373,6 @@ function discard_input(source::PortAudioSource)
         n = min(toread, CHUNKFRAMES)
         Pa_ReadStream(source.stream.stream, source.chunkbuf, n, false)
         toread -= n
-    end
-end
-
-macro stderr_as_debug(expression)
-    quote
-        debug_message = @capture_err result = $(esc(expression))
-        @debug debug_message
-        result
     end
 end
 

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -77,7 +77,6 @@ mutable struct PortAudioStream{T}
     samplerate::Float64
     latency::Float64
     stream::PaStream
-    warn_xruns::Bool
     recover_xruns::Bool
     sink # untyped because of circular type definition
     source # untyped because of circular type definition
@@ -91,7 +90,7 @@ mutable struct PortAudioStream{T}
     # TODO: figure out whether we can get deterministic latency...
     function PortAudioStream{T}(indev::PortAudioDevice, outdev::PortAudioDevice,
                                 inchans, outchans, sr,
-                                latency, warn_xruns, recover_xruns) where {T}
+                                latency, recover_xruns) where {T}
         inchans = inchans == -1 ? indev.maxinchans : inchans
         outchans = outchans == -1 ? outdev.maxoutchans : outchans
         inparams = (inchans == 0) ?
@@ -100,7 +99,7 @@ mutable struct PortAudioStream{T}
         outparams = (outchans == 0) ?
             Ptr{Pa_StreamParameters}(0) :
             Ref(Pa_StreamParameters(outdev.idx, outchans, type_to_fmt[T], latency, C_NULL))
-        this = new(sr, latency, C_NULL, warn_xruns, recover_xruns)
+        this = new(sr, latency, C_NULL, recover_xruns)
         # finalizer(close, this)
         this.sink = PortAudioSink{T}(outdev.name, this, outchans)
         this.source = PortAudioSource{T}(indev.name, this, inchans)
@@ -144,7 +143,7 @@ Audio devices can either be `PortAudioDevice` instances as returned
 by `PortAudio.devices()`, or strings with the device name as reported by the
 operating system. If a single `duplexdevice` is given it will be used for both
 input and output. If no devices are given the system default devices will be
-used.
+used. Over- and under-run messages will be sent to the debug log.
 
 Options:
 
@@ -152,9 +151,6 @@ Options:
 * `samplerate`:     Sample rate (defaults to device sample rate)
 * `latency`:        Requested latency. Stream could underrun when too low, consider
                     using provided device defaults
-* `warn_xruns`:     Display a warning if there is a stream overrun or underrun, which
-                    often happens when Julia is compiling, or with a particularly large
-                    GC run. This can be quite verbose so is false by default.
 * `recover_xruns`:  Attempt to recover from overruns and underruns by emptying and
                     filling the input and output buffers, respectively. Should result in
                     fewer xruns but could make each xrun more audible. True by default.
@@ -162,7 +158,7 @@ Options:
 """
 function PortAudioStream(indev::PortAudioDevice, outdev::PortAudioDevice,
         inchans=2, outchans=2; eltype=Float32, samplerate=-1,
-        latency=defaultlatency(indev, outdev), warn_xruns=false, recover_xruns=true)
+        latency=defaultlatency(indev, outdev), recover_xruns=true)
     if samplerate == -1
         sampleratein = indev.defaultsamplerate
         samplerateout = outdev.defaultsamplerate
@@ -178,7 +174,7 @@ function PortAudioStream(indev::PortAudioDevice, outdev::PortAudioDevice,
         end
     end
     PortAudioStream{eltype}(indev, outdev, inchans, outchans, samplerate,
-                            latency, warn_xruns, recover_xruns)
+                            latency, recover_xruns)
 end
 
 # handle device names given as streams
@@ -315,8 +311,7 @@ function SampledSignals.unsafe_write(sink::PortAudioSink, buf::Array, frameoffse
                    view(buf, (1:n) .+ nwritten .+ frameoffset, :))
         # TODO: if the stream is closed we just want to return a
         # shorter-than-requested frame count instead of throwing an error
-        err = Pa_WriteStream(sink.stream.stream, sink.chunkbuf, n,
-                             sink.stream.warn_xruns)
+        err = Pa_WriteStream(sink.stream.stream, sink.chunkbuf, n)
         if err ∈ (PA_OUTPUT_UNDERFLOWED, PA_INPUT_OVERFLOWED) && sink.stream.recover_xruns
             recover_xrun(sink.stream)
         end
@@ -332,8 +327,7 @@ function SampledSignals.unsafe_read!(source::PortAudioSource, buf::Array, frameo
         n = min(framecount-nread, CHUNKFRAMES)
         # TODO: if the stream is closed we just want to return a
         # shorter-than-requested frame count instead of throwing an error
-        err = Pa_ReadStream(source.stream.stream, source.chunkbuf, n,
-                            source.stream.warn_xruns)
+        err = Pa_ReadStream(source.stream.stream, source.chunkbuf, n)
         if err ∈ (PA_OUTPUT_UNDERFLOWED, PA_INPUT_OVERFLOWED) && source.stream.recover_xruns
             recover_xrun(source.stream)
         end

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -369,8 +369,9 @@ end
 
 macro stderr_as_debug(expression)
     quote
-        debug_message = @capture_err $(esc(expression))
+        debug_message = @capture_err result = $(esc(expression))
         @debug debug_message
+        result
     end
 end
 

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -1,6 +1,8 @@
 module PortAudio
 
-using libportaudio_jll, SampledSignals
+using libportaudio_jll: libportaudio_jll
+using SampledSignals
+using Suppressor: @capture_err
 
 import Base: eltype, show
 import Base: close, isopen
@@ -368,9 +370,8 @@ function discard_input(source::PortAudioSource)
 end
 
 function suppress_err(dofunc::Function)
-    io = IOBuffer()
-    redirect_stderr(dofunc, io)
-    @debug String(take!(io))
+    debug_message = @suppress_err dofunc()
+    @debug debug_message
 end
 
 function __init__()

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -368,10 +368,9 @@ function discard_input(source::PortAudioSource)
 end
 
 function suppress_err(dofunc::Function)
-    nullfile = @static Sys.iswindows() ? "nul" : "/dev/null"
-    open(nullfile, "w") do io
-        redirect_stderr(dofunc, io)
-    end
+    io = IOBuffer()
+    redirect_stderr(dofunc, io)
+    @debug String(take!(io))
 end
 
 function __init__()

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -19,7 +19,7 @@ macro stderr_as_debug(expression)
     quote
         local result
         debug_message = @capture_err result = $(esc(expression))
-        @debug "$debug_message"
+        @debug debug_message
         result
     end
 end

--- a/src/libportaudio.jl
+++ b/src/libportaudio.jl
@@ -242,8 +242,7 @@ function Pa_GetStreamWriteAvailable(stream::PaStream)
     avail
 end
 
-function Pa_ReadStream(stream::PaStream, buf::Array, frames::Integer,
-                       show_warnings=true)
+function Pa_ReadStream(stream::PaStream, buf::Array, frames::Integer)
     # without disable_sigint I get a segfault with the error:
     # "error thrown and no exception handler available."
     # if the user tries to ctrl-C. Note I've still had some crash problems with
@@ -254,18 +253,17 @@ function Pa_ReadStream(stream::PaStream, buf::Array, frames::Integer,
                              (PaStream, Ptr{Cvoid}, Culong),
                              stream, buf, frames)
     end
-    handle_status(err, show_warnings)
+    handle_status(err)
     err
 end
 
-function Pa_WriteStream(stream::PaStream, buf::Array, frames::Integer,
-                        show_warnings=true)
+function Pa_WriteStream(stream::PaStream, buf::Array, frames::Integer)
     err = disable_sigint() do
         @tcall @locked ccall((:Pa_WriteStream, libportaudio), PaError,
                              (PaStream, Ptr{Cvoid}, Culong),
                              stream, buf, frames)
     end
-    handle_status(err, show_warnings)
+    handle_status(err)
     err
 end
 
@@ -279,13 +277,12 @@ end
 # end
 #
 # General utility function to handle the status from the Pa_* functions
-function handle_status(err::PaError, show_warnings::Bool=true)
+function handle_status(err::PaError)
     if err == PA_OUTPUT_UNDERFLOWED || err == PA_INPUT_OVERFLOWED
-        if show_warnings
-            msg = @locked ccall((:Pa_GetErrorText, libportaudio),
-                        Ptr{Cchar}, (PaError,), err)
-            @warn("libportaudio: " * unsafe_string(msg))
-        end
+        @debug unsafe_string(
+            @locked ccall((:Pa_GetErrorText, libportaudio),
+                Ptr{Cchar}, (PaError,), err)
+        )
     elseif err != PA_NO_ERROR
         msg = @locked ccall((:Pa_GetErrorText, libportaudio),
                     Ptr{Cchar}, (PaError,), err)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,17 @@
 #!/usr/bin/env julia
 
+using Logging: Debug
 using PortAudio
-using PortAudio: Pa_GetDefaultInputDevice, Pa_GetDefaultOutputDevice, Pa_GetDeviceInfo, Pa_GetHostApiInfo, PortAudioDevice
+using PortAudio: Pa_GetDefaultInputDevice, Pa_GetDefaultOutputDevice, Pa_GetDeviceInfo, Pa_GetHostApiInfo, PortAudioDevice, @stderr_as_debug
 using Test
 using SampledSignals
+
+@testset "Debug messages" begin
+    @test_logs (:debug, "hi") min_level = Debug @test_nowarn @stderr_as_debug begin
+        print(stderr, "hi")
+        true
+    end
+end
 
 @testset "PortAudio Tests" begin
     @testset "Reports version" begin


### PR DESCRIPTION
It looks like PortAudio prints a bunch of debug information to stdout when it starts up. The current code suppresses this, but I'm not convinced it's the best idea. The warnings seem to contain valuable debug information, see https://github.com/alsa-project/alsa-plugins/issues/20 for example.
