### PR TITLE
Remove documentation for depreciated synced keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ julia> PortAudio.devices()
  PortAudio.PortAudioDevice("Built-In Aggregate","Core Audio",2,2,5)
 ```
 
-### Input/Output Synchronization
-
-The `synced` keyword argument to `PortAudioStream` controls whether the input and output ringbuffers are kept synchronized or not, which only effects duplex streams. It should be set to `true` if you need consistent input-to-output latency. In a synchronized stream, the underlying PortAudio callback will only read and write to the buffers an equal number of frames. In a synchronized stream, the user must also read and write an equal number of frames to the stream. If it is only written to or read from, it will eventually block. This is why it is `false` by default.
-
-
 ## Reading and Writing
 
 The `PortAudioStream` type has `source` and `sink` fields which are of type `PortAudioSource <: SampleSource` and `PortAudioSink <: SampleSink`, respectively. are subtypes of `SampleSource` and `SampleSink`, respectively (from [SampledSignals.jl](https://github.com/JuliaAudio/SampledSignals.jl)). This means they support all the stream and buffer features defined there. For example, if you load SampledSignals with `using SampledSignals` you can read 5 seconds to a buffer with `buf = read(stream.source, 5s)`, regardless of the sample rate of the device.


### PR DESCRIPTION
#### What does this implement/fix? 
Remove documentation for depreciated `synced` keyword


#### Reference issue
Closes #37 


#### Additional information
See https://github.com/JuliaAudio/PortAudio.jl/issues/37#issuecomment-897313292

> We lost synced when I switched from the callback implemented in C to using libportaudio's streaming interface. It made the code a lot simpler but we lost some low-level control and are relying on portaudio to manage the io buffers.
> Previously the C callback would stop pushing/pulling from the write/read ringbuffers when either one of them was full/empty (respectively). That ensured that the ringbuffer state was always synchronized, but made things trickier to manage because the system would hang up if you tried to read from a stream without simultaneously writing to it, or vice-versa.
> In general it was a headache and it seemed like the vast majority of users don't really care about deterministic round-trip latency, so I gave it up. This isn't great if you're using it to try to do impulse response measurements or something, but changes in the round-trip latency should only happen on under/overflow, so your measurement would be hosed anyways.
