### PR TITLE
avoid fields with abstract types

### DIFF
--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -379,7 +379,7 @@ Use [`PortAudio.write_buffer`](@ref) to write data to PortAudio, and [`PortAudio
 struct Buffer{Sample}
     stream_lock::ReentrantLock
     pointer_to::Ptr{PaStream}
-    data::Array{Sample}
+    data::Array{Sample, 2}
     number_of_channels::Int
     frames_per_buffer::Int
     warn_xruns::Bool


### PR DESCRIPTION
The [Julia documentation](https://docs.julialang.org/en/v1/manual/performance-tips/#Avoid-fields-with-abstract-type) states that fields with abstract types can lead to performance problems. 

`Buffer` contains the field  `data::Array{Sample} where Sample`. This type has a free parameter, namely the dimension of the array, and therefore , it will lead to type-instability when calling the function  `getproperty(buffer, :data)`. 

I believe, from experiments on my local machine, the type-instability is leading to unnecessary allocations when calling `PortAudio.read_or_write` (which ideally should have 0 allocations for real-time applications?). When running the following code:

```
s = PortAudioStream(1,0 ; warn_xruns = false)
@ballocated(PortAudio.read_or_write(PortAudio.Pa_ReadStream, $(s).source_messanger.buffer))

3
```

By updating the field type such that it is now of type `Array{Sample, 2}`, retrieving the raw data is now type-stable and allocations are removed.