### PR TITLE
Fix remaining messanger typos, add docstring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PortAudio"
 uuid = "80ea8bcb-4634-5cb3-8ee8-a132660d1d2d"
 repo = "https://github.com/JuliaAudio/PortAudio.jl.git"
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 alsa_plugins_jll = "5ac2f6bb-493e-5871-9171-112d4c21a6e7"


### PR DESCRIPTION
Fixes #113, adds a docstring, and bumps the version because technically the change to some non-exported function names still is breaking.