### PR TITLE
Back to v1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PortAudio"
 uuid = "80ea8bcb-4634-5cb3-8ee8-a132660d1d2d"
 repo = "https://github.com/JuliaAudio/PortAudio.jl.git"
-version = "1.3.0"
+version = "1.2.0"
 
 [deps]
 alsa_plugins_jll = "5ac2f6bb-493e-5871-9171-112d4c21a6e7"


### PR DESCRIPTION
I was about to register v1.3 when I noticed that we never registered v1.2 from #98.
We can't skip versions so we must first accept this PR to get the toml file back to v1.2,
and then we can register it.