### PR TITLE
small fixes to examples and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or a variety of other keyword arguments.
 If named keyword arguments `latency` or `samplerate` are unspecified, then PortAudio will use device defaults.
 
 ```julia
-PortAudioStream(inchans=2, outchans=2; eltype=Float32, samplerate=48000, latency=0.1)
+PortAudioStream(; eltype=Float32, samplerate=48000, latency=0.1)
 ```
 
 You can open a specific device by adding it as the first argument, either as a `PortAudioDevice` instance or by name. You can also give separate names or devices if you want different input and output devices
@@ -45,7 +45,7 @@ julia> PortAudio.devices()
 
 ## Reading and Writing
 
-The `PortAudioStream` type has `source` and `sink` fields which are of type `PortAudioSource <: SampleSource` and `PortAudioSink <: SampleSink`, respectively. are subtypes of `SampleSource` and `SampleSink`, respectively (from [SampledSignals.jl](https://github.com/JuliaAudio/SampledSignals.jl)). This means they support all the stream and buffer features defined there. For example, if you load SampledSignals with `using SampledSignals` you can read 5 seconds to a buffer with `buf = read(stream.source, 5s)`, regardless of the sample rate of the device.
+The `PortAudioStream` type has `source` and `sink` fields which are of type `PortAudioSource <: SampleSource` and `PortAudioSink <: SampleSink`, respectively. They are subtypes of `SampleSource` and `SampleSink`, respectively (from [SampledSignals.jl](https://github.com/JuliaAudio/SampledSignals.jl)). This means they support all the stream and buffer features defined there. For example, if you load SampledSignals with `using SampledSignals` you can read 5 seconds to a buffer with `buf = read(stream.source, 5s)`, regardless of the sample rate of the device.
 
 PortAudio.jl also provides convenience wrappers around the `PortAudioStream` type so you can read and write to it directly, e.g. `write(stream, stream)` will set up a loopback that will read from the input and play it back on the output.
 

--- a/examples/lilyplay.jl
+++ b/examples/lilyplay.jl
@@ -7,7 +7,7 @@ const DEFAULTDEVICE = -1
 function paudio()
     devs = PortAudio.devices()
     if DEFAULTDEVICE < 0
-        devnum = findfirst(x -> x.maxoutchans > 0, devs)
+        devnum = findfirst(x -> x.output_bounds.max_channels > 0, devs)
         (devnum == nothing) && error("No output device for audio found")
     else
         devnum = DEFAULTDEVICE + 1

--- a/examples/waterfall_heatmap.jl
+++ b/examples/waterfall_heatmap.jl
@@ -1,4 +1,5 @@
 using Makie
+using FFTW
 using PortAudio
 using DSP
 
@@ -18,7 +19,7 @@ takes a block of audio, FFT it, and write it to the beginning of the buffer
 """
 function processbuf!(readbuf, win, dispbuf, fftbuf, fftplan)
     readbuf .*= win
-    A_mul_B!(fftbuf, fftplan, readbuf)
+    fftbuf = fftplan * readbuf
     shift1!(dispbuf)
     @. dispbuf[end:-1:1, 1] = log(clamp(abs(fftbuf[1:D]), 0.0001, Inf))
 end
@@ -35,9 +36,9 @@ N2 = N ÷ 2 + 1 # size of rfft output
 D = 200 # number of bins to display
 M = 200 # amount of history to keep
 src = PortAudioStream(1, 2)
-buf = Array{Float32}(N) # buffer for reading
+buf = Array{Float32}(undef, N) # buffer for reading
 fftplan = plan_rfft(buf; flags = FFTW.EXHAUSTIVE)
-fftbuf = Array{Complex{Float32}}(N2) # destination buf for FFT
+fftbuf = Array{Complex{Float32}}(undef, N2) # destination buf for FFT
 dispbufs = [zeros(Float32, D, M) for i in 1:5, j in 1:5] # STFT bufs
 win = gaussian(N, 0.125)
 

--- a/examples/waterfall_lines.jl
+++ b/examples/waterfall_lines.jl
@@ -1,4 +1,4 @@
-using Makie, GeometryTypes
+using Makie, GeometryTypes, FFTW
 using PortAudio
 
 N = 1024 # size of audio read
@@ -7,9 +7,9 @@ D = 200 # number of bins to display
 M = 100 # number of lines to draw
 S = 0.5 # motion speed of lines
 src = PortAudioStream(1, 2)
-buf = Array{Float32}(N)
-fftbuf = Array{Complex{Float32}}(N2)
-magbuf = Array{Float32}(N2)
+buf = Array{Float32}(undef, N)
+fftbuf = Array{Complex{Float32}}(undef, N2)
+magbuf = Array{Float32}(undef, N2)
 fftplan = plan_rfft(buf; flags = FFTW.EXHAUSTIVE)
 
 scene = Scene(resolution = (500, 500))


### PR DESCRIPTION
#### What does this implement/fix? 
This is a small PR fixing typos in the README and a few examples


#### Reference issue
Discussed briefly here: #114 


#### Additional information
I couldn't get the `waterfall_lines.jl`, `lilyplay.jl` or `waterfall_heatmap.jl` examples to run. Here are my rough thoughts on them:

1. `lilyplay.jl`. I am not really sure what this one should be doing exactly, but it provides the following error:

```
Freude, schöner Götterfunken, Tochter aus Elisium! Wir betreten feuertrunken, Himmlische, dein Heiligthum! Deine Zauber bin den wieder, was die Mode streng getheilt, alle menschen werden Brüder wo dein sanfter Flügel weilt.
 Expression 'ret' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 1742
Expression 'AlsaOpen( &alsaApi->baseHostApiRep, params, streamDir, &self->pcm )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 1909
Expression 'PaAlsaStreamComponent_Initialize( &self->playback, alsaApi, outParams, StreamDirection_Out, NULL != callback )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 2177
Expression 'PaAlsaStream_Initialize( stream, alsaHostApi, inputParameters, outputParameters, sampleRate, framesPerBuffer, callback, streamFlags, userData )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 2843
Expression 'ret' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 1742
Expression 'AlsaOpen( &alsaApi->baseHostApiRep, params, streamDir, &self->pcm )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 1909
Expression 'PaAlsaStreamComponent_Initialize( &self->playback, alsaApi, outParams, StreamDirection_Out, NULL != callback )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 2177
Expression 'PaAlsaStream_Initialize( stream, alsaHostApi, inputParameters, outputParameters, sampleRate, framesPerBuffer, callback, streamFlags, userData )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 2843
Expression 'ret' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 1742
Expression 'AlsaOpen( &alsaApi->baseHostApiRep, params, streamDir, &self->pcm )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 1909
Expression 'PaAlsaStreamComponent_Initialize( &self->playback, alsaApi, outParams, StreamDirection_Out, NULL != callback )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 2177
Expression 'PaAlsaStream_Initialize( stream, alsaHostApi, inputParameters, outputParameters, sampleRate, framesPerBuffer, callback, streamFlags, userData )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 2843
Expression 'ret' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 1742
Expression 'AlsaOpen( &alsaApi->baseHostApiRep, params, streamDir, &self->pcm )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 1909
Expression 'PaAlsaStreamComponent_Initialize( &self->playback, alsaApi, outParams, StreamDirection_Out, NULL != callback )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 2177
Expression 'PaAlsaStream_Initialize( stream, alsaHostApi, inputParameters, outputParameters, sampleRate, framesPerBuffer, callback, streamFlags, userData )' failed in '/workspace/srcdir/portaudio/src/hostapi/alsa/pa_linux_alsa.c', line: 2843
ERROR: LoadError: PortAudioException: Device unavailable
Stacktrace:
  [1] handle_status(error_number::Int32; warn_xruns::Bool)
    @ PortAudio ~/projects/PortAudio.jl/src/PortAudio.jl:102
  [2] handle_status
    @ ~/projects/PortAudio.jl/src/PortAudio.jl:93 [inlined]
  [3] PortAudioStream(input_device::PortAudio.PortAudioDevice, output_device::PortAudio.PortAudioDevice, input_channels::Int64, output_channels::Int64; eltype::Type, adjust_channels::Bool, call_back::Ptr{Nothing}, flags::UInt64, frames_per_buffer::Int64, input_info::Ptr{Nothing}, latency::Nothing, output_info::Ptr{Nothing}, reader::PortAudio.SampledSignalsReader, samplerate::Nothing, stream_lock::ReentrantLock, user_data::Ptr{Nothing}, warn_xruns::Bool, writer::PortAudio.SampledSignalsWriter)
    @ PortAudio ~/projects/PortAudio.jl/src/PortAudio.jl:779
  [4] PortAudioStream
    @ ~/projects/PortAudio.jl/src/PortAudio.jl:721 [inlined]
  [5] #PortAudioStream#16
    @ ~/projects/PortAudio.jl/src/PortAudio.jl:842 [inlined]
  [6] PortAudioStream
    @ ~/projects/PortAudio.jl/src/PortAudio.jl:842 [inlined]
  [7] #PortAudioStream#17
    @ ~/projects/PortAudio.jl/src/PortAudio.jl:857 [inlined]
  [8] PortAudioStream
    @ ~/projects/PortAudio.jl/src/PortAudio.jl:857 [inlined]
  [9] paudio()
    @ Main ~/projects/PortAudio.jl/examples/lilyplay.jl:15
 [10] parsevoice(melody::String; tempo::Int64, beatunit::Int64, lyrics::String)
    @ Main ~/projects/PortAudio.jl/examples/lilyplay.jl:45
 [11] #12
    @ ~/builds/julia-1.7.1/share/julia/stdlib/v1.7/Distributed/src/macros.jl:43 [inlined]
 [12] run_work_thunk(thunk::var"#12#13", print_error::Bool)
    @ Distributed ~/builds/julia-1.7.1/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:63
 [13] run_work_thunk
    @ ~/builds/julia-1.7.1/share/julia/stdlib/v1.7/Distributed/src/process_messages.jl:72 [inlined]
 [14] (::Distributed.var"#96#98"{Distributed.RemoteValue, var"#12#13"})()
    @ Distributed ./task.jl:423
Stacktrace:
 [1] wait_ref
   @ ~/builds/julia-1.7.1/share/julia/stdlib/v1.7/Distributed/src/remotecall.jl:577 [inlined]
 [2] call_on_owner
   @ ~/builds/julia-1.7.1/share/julia/stdlib/v1.7/Distributed/src/remotecall.jl:567 [inlined]
 [3] wait(r::Future)
   @ Distributed ~/builds/julia-1.7.1/share/julia/stdlib/v1.7/Distributed/src/remotecall.jl:590
 [4] top-level scope
   @ ~/projects/PortAudio.jl/examples/lilyplay.jl:156
 [5] include(fname::String)
   @ Base.MainInclude ./client.jl:451
 [6] top-level scope
   @ REPL[6]:1
in expression starting at /home/leios/projects/PortAudio.jl/examples/lilyplay.jl:156
```

2. `waterfall_lines.jl`. This one seems to be broken because of Makie.jl has changed it's API. I don't really know what `ax = axis(0:0.1:1, 0:0.1:1, 0:0.1:0.5)` is in modern Makie
3. `waterfall_heatmap.jl`. I am not sure what the following lines are supposed to be doing:
```
heatmaps = map(enumerate(IndexCartesian(), dispbufs)) do ibuf
    i = ibuf[1]
    buf = ibuf[2]

    # some function of the 2D index and the value
    heatmap(buf, offset = (i[2] * size(buf, 2), i[1] * size(buf, 1)))
end
```
It seems to be broken on `enumerate(IndexCartesian(), dispbufs)`. `dispbufs` is a 2D array of 2D arrays and `enumerate(IndexCartesian(), a)` no longer exists. I tried `CartesianIndices(...)`, but obviously `i` and `buf` are integers in this case, so `heatmap(buf, offset = (i[2] * size(buf, 2), i[1] * size(buf, 1)))` breaks

I'll keep working on this, I am just creating the PR prematurely to see what you think.