### PR TITLE
Allow skipping locks, precompile

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PortAudio"
 uuid = "80ea8bcb-4634-5cb3-8ee8-a132660d1d2d"
 repo = "https://github.com/JuliaAudio/PortAudio.jl.git"
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 alsa_plugins_jll = "5ac2f6bb-493e-5871-9171-112d4c21a6e7"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ SampledSignals = "bd7594eb-a658-542f-9e75-4c4d8908c167"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [compat]
-julia = "1.3"
+julia = "1.6"
 alsa_plugins_jll = "1.2.2"
 libportaudio_jll = "19.6.0"
 SampledSignals = "2.1.1"

--- a/src/PortAudio.jl
+++ b/src/PortAudio.jl
@@ -133,7 +133,7 @@ function __init__()
         config_folder = "ALSA_CONFIG_DIR"
         if config_folder ∉ keys(ENV)
             ENV[config_folder] =
-                seek_alsa_conf(["/usr/share/alsa", "/usr/local/share/alsa", "/etc/alsa"])
+                seek_alsa_conf(("/usr/share/alsa", "/usr/local/share/alsa", "/etc/alsa"))
         end
         # the plugin folder will contain plugins for, critically, PulseAudio
         plugin_folder = "ALSA_PLUGIN_DIR"
@@ -604,10 +604,9 @@ function combine_default_sample_rates(
 )
     if input_sample_rate != output_sample_rate
         throw(
-            ArgumentError(
-                """
-Default sample rate $input_sample_rate for input $(name(input_device)) disagrees with
-default sample rate $output_sample_rate for output $(name(output_device)).
+            ArgumentError("""
+Default sample rate $input_sample_rate for input \"$(name(input_device))\" disagrees with
+default sample rate $output_sample_rate for output \"$(name(output_device))\".
 Please specify a sample rate.
 """,
             ),

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,29 @@
+# precompile some important functions
+const DEFAULT_SINK_MESSENGER_TYPE = Messenger{Float32, SampledSignalsWriter, Tuple{Matrix{Float32}, Int64, Int64}, Int64}
+const DEFAULT_SOURCE_MESSENGER_TYPE = Messenger{Float32, SampledSignalsReader, Tuple{Matrix{Float32}, Int64, Int64}, Int64}
+const DEFAULT_STREAM_TYPE = PortAudioStream{DEFAULT_SINK_MESSENGER_TYPE, DEFAULT_SOURCE_MESSENGER_TYPE}
+const DEFAULT_SINK_TYPE = PortAudioSink{DEFAULT_SINK_MESSENGER_TYPE, DEFAULT_SOURCE_MESSENGER_TYPE}
+const DEFAULT_SOURCE_TYPE = PortAudioSource{DEFAULT_SINK_MESSENGER_TYPE, DEFAULT_SOURCE_MESSENGER_TYPE}
+
+precompile(close, (DEFAULT_STREAM_TYPE,))
+precompile(devices, ())
+precompile(__init__, ())
+precompile(isopen, (DEFAULT_STREAM_TYPE,))
+precompile(nchannels, (DEFAULT_SINK_TYPE,))
+precompile(nchannels, (DEFAULT_SOURCE_TYPE,))
+precompile(PortAudioStream, (Int, Int))
+precompile(PortAudioStream, (String, Int, Int))
+precompile(PortAudioStream, (String, String, Int, Int))
+precompile(samplerate, (DEFAULT_STREAM_TYPE,))
+precompile(send, (DEFAULT_SINK_MESSENGER_TYPE,))
+precompile(send, (DEFAULT_SOURCE_MESSENGER_TYPE,))
+precompile(unsafe_read!, (DEFAULT_SOURCE_TYPE, Vector{Float32}, Int, Int))
+precompile(unsafe_read!, (DEFAULT_SOURCE_TYPE, Matrix{Float32}, Int, Int))
+precompile(unsafe_write, (DEFAULT_SINK_TYPE, Vector{Float32}, Int, Int))
+precompile(unsafe_write, (DEFAULT_SINK_TYPE, Matrix{Float32}, Int, Int))
+
+
+
+
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,11 +134,11 @@ if !isempty(devices())
             source = stream.source
             @test sprint(show, stream) == """
                 PortAudioStream{Float32}
-                  Samplerate: 44100.0Hz
-                  2 channel sink: $(repr(input_name))
-                  2 channel source: $(repr(output_name))"""
-            @test sprint(show, source) == "2 channel source: $(repr(output_name))"
-            @test sprint(show, sink) == "2 channel sink: $(repr(input_name))"
+                  Samplerate: 44100Hz
+                  2 channel sink: $(repr(output_name))
+                  2 channel source: $(repr(input_name))"""
+            @test sprint(show, source) == "2 channel source: $(repr(input_name))"
+            @test sprint(show, sink) == "2 channel sink: $(repr(output_name))"
             write(stream, stream, 5s)
             @test PaErrorCode(handle_status(Pa_StopStream(stream.pointer_to))) == paNoError
             @test isopen(stream)
@@ -209,8 +209,8 @@ if !isempty(devices())
             big = typemax(Int)
             @test_throws DomainError(
                 typemax(Int),
-                "$big exceeds maximum input channels for $output_name",
-            ) PortAudioStream(input_name, output_name, big, 0)
+                "$big exceeds maximum output channels for $output_name",
+            ) PortAudioStream(input_name, output_name, 0, big)
             @test_throws ArgumentError("Input or output must have at least 1 channel") PortAudioStream(
                 input_name,
                 output_name,
@@ -219,8 +219,8 @@ if !isempty(devices())
                 adjust_channels = true,
             )
             @test_throws ArgumentError("""
-            Default sample rate 0 for input $output_name disagrees with
-            default sample rate 1 for output $input_name.
+            Default sample rate 0 for input \"$input_name\" disagrees with
+            default sample rate 1 for output \"$output_name\".
             Please specify a sample rate.
             """) combine_default_sample_rates(
                 get_device(input_name),


### PR DESCRIPTION
I added a Bool keyword argument to` write_buffer and read_buffer to allow skipping the lock. This is useful to speed up performance in places where you know no other thread is going to be reading or writing to the buffer. I also added a handful of precompilation statements for some front-end and/or important functions.